### PR TITLE
added spectra_verbosity functionality

### DIFF
--- a/src/read_input.f90
+++ b/src/read_input.f90
@@ -230,6 +230,15 @@ CONTAINS
                 ELSEIF (INDEX(to_lower(line), 'fwhm')>0) THEN
                     READ (line, *) dummy, gs%fwhm
                     WRITE (*, '(4X,A, T60, F0.4)') 'FWHM for Gaussian broadening (cm^-1):', gs%fwhm
+                ELSEIF (INDEX(to_lower(line), 'spectra_verbosity')>0) THEN 
+                    READ (line, *) dummy, gs%spectra_verbosity
+                    IF (TRIM(gs%spectra_verbosity)/= 'normal' .AND. TRIM(gs%spectra_verbosity)/= 'high' ) THEN
+                        WRITE (error_unit, '(4X,"[WARN] ",A)') 'spectra verbosity incorrectly defined in the input.'
+                        WRITE (error_unit, '(4X,"[WARN] ",A)') 'Please use keyword "normal" or "high".'
+                        gs%spectra_verbosity = 'normal'
+                        WRITE (error_unit, '(4X,"[WARN] ",A)') 'Spectra verbosity is now set to normal'
+                    END IF
+                    WRITE (*, '(4X,A, T60, A)') 'Spectra output verbosity:', gs%spectra_verbosity
                 ELSEIF (INDEX(to_lower(line), 'spectra')>0) THEN
                     READ (line, *) dummy, gs%spectral_type%read_function
                     WRITE (*, '(4X,A, T60, A)') 'spectra:', TRIM(gs%spectral_type%read_function)

--- a/src/spectra.f90
+++ b/src/spectra.f90
@@ -275,7 +275,6 @@ CONTAINS
     !!!ORTHOGONAL!!!
 
              ! Label z. B. "laser_1", "laser_2", ...
-           
             DO i = 0, 2*md%t_cor - 2
                 IF (i_laser == 1) THEN
                 zhat_aniso(i + 1) = REAL(zhat_aniso(i + 1), kind=dp)*(f*(i + 1)/SIN(f*(i + 1)))**2._dp
@@ -285,14 +284,16 @@ CONTAINS
                 IF (freq(i).GE.5000.0_dp) CYCLE
             !    WRITE (runit, *) freq(i), raman_ortho(i)
             END DO
-            outfile = "raman_orthogonal.txt"
-            WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-            IF (i_laser == 1) THEN
-                !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_ortho(:), freq, 5000.0_dp)
-                CALL write_spectra_data(outfile, c_label, freq, raman_ortho(:), 5000.0_dp)
-            ELSE
-                !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-                CALL append_column(outfile, c_label, raman_ortho(:), freq, 5000.0_dp)
+            IF (gs%spectra_verbosity == 'high') THEN
+                outfile = "raman_orthogonal.txt"
+                WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                IF (i_laser == 1) THEN
+                    !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_ortho(:), freq, 5000.0_dp)
+                    CALL write_spectra_data(outfile, c_label, freq, raman_ortho(:), 5000.0_dp)
+                ELSE
+                    !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                    CALL append_column(outfile, c_label, raman_ortho(:), freq, 5000.0_dp)
+                END IF
             END IF
             !WRITE(fname,'("raman_orthogonal_laser_",F0.6,"eV.txt")') rams%laser_in(i_laser)
             !IF (i_laser==1) THEN
@@ -331,14 +332,16 @@ CONTAINS
                 IF (freq(i).GE.5000.0_dp) CYCLE
                 !WRITE (runit, *) freq(i), raman_para(i)
             END DO
-            outfile = "raman_parallel.txt"
-            WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-            IF (i_laser == 1) THEN
-                !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_para(:), freq, 5000.0_dp)
-                CALL write_spectra_data(outfile, c_label, freq, raman_para(:), 5000.0_dp)
-            ELSE
-                !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-                CALL append_column(outfile, c_label, raman_para(:), freq, 5000.0_dp)
+            IF (gs%spectra_verbosity == 'high') THEN
+                outfile = "raman_parallel.txt"
+                WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                IF (i_laser == 1) THEN
+                    !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_para(:), freq, 5000.0_dp)
+                    CALL write_spectra_data(outfile, c_label, freq, raman_para(:), 5000.0_dp)
+                ELSE
+                    !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                    CALL append_column(outfile, c_label, raman_para(:), freq, 5000.0_dp)
+                END IF
             END IF
             !CLOSE (runit)
 
@@ -358,14 +361,16 @@ CONTAINS
                 IF (freq(i).GE.5000.0_dp) CYCLE
                 !WRITE (runit, *) freq(i), raman_unpol(i)
             END DO
-            outfile = "raman_unpolarized.txt"
-            WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-            IF (i_laser == 1) THEN
-                !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_unpol(:), freq, 5000.0_dp)
-                CALL write_spectra_data(outfile, c_label, freq, raman_unpol(:), 5000.0_dp)
-            ELSE
-                !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-                CALL append_column(outfile, c_label, raman_unpol(:), freq, 5000.0_dp)
+            IF (gs%spectra_verbosity == 'high' .OR. gs%spectra_verbosity == 'normal') THEN
+                outfile = "raman_unpolarized.txt"
+                WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                IF (i_laser == 1) THEN
+                    !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_unpol(:), freq, 5000.0_dp)
+                    CALL write_spectra_data(outfile, c_label, freq, raman_unpol(:), 5000.0_dp)
+                ELSE
+                    !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                    CALL append_column(outfile, c_label, raman_unpol(:), freq, 5000.0_dp)
+                END IF
             END IF
             !CLOSE (runit)
 
@@ -386,14 +391,16 @@ CONTAINS
                 IF (freq(i).GE.5000.0_dp) CYCLE
                 !WRITE (runit, *) freq(i), raman_depol(i)
             END DO
-            outfile = "raman_depolarization_ratio.txt"
-            WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-            IF (i_laser == 1) THEN
-                !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_depol(:), freq, 5000.0_dp)
-                CALL write_spectra_data(outfile, c_label, freq, raman_depol(:), 5000.0_dp)
-            ELSE
-                !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
-                CALL append_column(outfile, c_label, raman_depol(:), freq, 5000.0_dp)
+            IF (gs%spectra_verbosity == 'high') THEN
+                outfile = "raman_depolarization_ratio.txt"
+                WRITE(c_label, '("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                IF (i_laser == 1) THEN
+                    !CALL write_spectra_data(outfile, c_label, 1,  2*md%t_cor - 2, raman_depol(:), freq, 5000.0_dp)
+                    CALL write_spectra_data(outfile, c_label, freq, raman_depol(:), 5000.0_dp)
+                ELSE
+                    !WRITE(c_label,'("INT ",F10.6, " eV")') rams%laser_in(i_laser)
+                    CALL append_column(outfile, c_label, raman_depol(:), freq, 5000.0_dp)
+                END IF
             END IF
             !CLOSE (runit)
         END DO

--- a/src/vib_types.f90
+++ b/src/vib_types.f90
@@ -117,6 +117,7 @@ MODULE vib_types
         TYPE(spectral_type)                              ::  spectral_type ! global setting of spectral type 'P' , 'IR' , 'R' etc.
         REAL(kind=dp)                                       ::  temp
         REAL(kind=dp)                                       ::  fwhm
+        CHARACTER(LEN=40)                                   :: spectra_verbosity
     END TYPE global_settings
 
     !***************************************************************************
@@ -384,7 +385,7 @@ CONTAINS
 
     SUBROUTINE init_global_settings(gs)
         TYPE(global_settings), INTENT(out) :: gs
-
+        gs%spectra_verbosity = 'normal'
         gs%temp = -1.0_dp
         gs%spectral_type%read_function = ''
     END SUBROUTINE init_global_settings


### PR DESCRIPTION
the spectra_verbosity variable is implemented to allow the adjustment of spectra files. this is now only implemented and relevant for dynamic raman calculation. Here, normal verbosity limits the output to the unpolarized raman spectra.