### PR TITLE
export fortran compiler to greenx

### DIFF
--- a/cmake/greenx_dependency.cmake
+++ b/cmake/greenx_dependency.cmake
@@ -23,6 +23,7 @@ else()
                    -DCOMPILE_SUBMODULES=OFF
                    -DENABLE_GNU_GMP=OFF
                    -DENABLE_GREENX_CTEST=OFF
+                   -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
         BUILD_COMMAND make -j 
         INSTALL_COMMAND make install && rm -rf ${CMAKE_BINARY_DIR}/external/greenx/src/greenx/.git/
         GIT_SUBMODULES ""


### PR DESCRIPTION
@muralidhar-nalabothula pointed out in openjournals/joss-reviews#10136 that the Fortran compiler is not forwarded to greenX 

To adress this, the compiler has to be exported to greenX when loading the external library.